### PR TITLE
v0.2.0 Release

### DIFF
--- a/README.md
+++ b/README.md
@@ -3,6 +3,12 @@ This package contains some additions to Akka.Persistence that many users commonl
 
 You can read more about Akka.Persistence.Extras at: https://devops.petabridge.com/articles/msgdelivery/
 
+You can install these tools via the [Akka.Persistence.Extras NuGet Package](https://www.nuget.org/packages/Akka.Persistence.Extras/)
+
+```
+PS> Install-Package Akka.Persistence.Extras
+```
+
 ## `AtLeastOnceDeliveryActorV2`
 
 The [`AtLeastOnceDeliveryActor` base type](https://getakka.net/api/Akka.Persistence.AtLeastOnceDeliveryActor.html) in its current form is a total non-pleasure to use in production, for the following reasons:

--- a/RELEASE_NOTES.md
+++ b/RELEASE_NOTES.md
@@ -1,4 +1,5 @@
-#### 0.1.0 February 14 2019 ####
-First release of Akka.Persistence.Extras. Introduces the [`DeDuplicatingReceiveActor` base class](https://devops.petabridge.com/api/Akka.Persistence.Extras.DeDuplicatingReceiveActor.html), which can be used to automatically strip out duplicates and guarantee that messages are processed exactly once by the actor.
+#### 0.2.0 February 15 2019 ####
+Minor, but breaking change release of Akka.Persistence.Extras.
 
-You can read more about [how to use the `DeDuplicatingReceiveActor` with Akka.NET and other `AtLeastOnceDeliveryActor` instances here](https://devops.petabridge.com/articles/msgdelivery/deduplication.html).
+* Changed targets to .NET 4.5 and .NET Standard 1.6, in order to temporarily bring the project inline with Akka.NET's targets. We will move back to targeting .NET Standard 2.0 eventually.
+* Removed all dependencies on `System.ValueTuple` as this caused compilation issues on Linux with .NET Framework 4.5.

--- a/src/Akka.Persistence.Extras.Demo.DeDuplicatingReceiver/Akka.Persistence.Extras.Demo.DeDuplicatingReceiver.csproj
+++ b/src/Akka.Persistence.Extras.Demo.DeDuplicatingReceiver/Akka.Persistence.Extras.Demo.DeDuplicatingReceiver.csproj
@@ -4,6 +4,7 @@
   <PropertyGroup>
     <OutputType>Exe</OutputType>
     <TargetFramework>netcoreapp2.1</TargetFramework>
+    <IsPackable>false</IsPackable>
   </PropertyGroup>
 
   <ItemGroup>

--- a/src/Akka.Persistence.Extras.Tests.Performance/Akka.Persistence.Extras.Tests.Performance.csproj
+++ b/src/Akka.Persistence.Extras.Tests.Performance/Akka.Persistence.Extras.Tests.Performance.csproj
@@ -5,6 +5,7 @@
   <PropertyGroup>    
     <TargetFramework>netcoreapp2.1</TargetFramework>
     <GenerateRuntimeConfigurationFiles>true</GenerateRuntimeConfigurationFiles>
+    <IsPackable>false</IsPackable>
     <RuntimeFrameworkVersion>2.1.6</RuntimeFrameworkVersion>
   </PropertyGroup>
 

--- a/src/Akka.Persistence.Extras.Tests/Akka.Persistence.Extras.Tests.csproj
+++ b/src/Akka.Persistence.Extras.Tests/Akka.Persistence.Extras.Tests.csproj
@@ -3,6 +3,7 @@
 
   <PropertyGroup>    
     <TargetFramework>netcoreapp2.1</TargetFramework>
+    <IsPackable>false</IsPackable>
   </PropertyGroup>
 
   <ItemGroup>

--- a/src/Akka.Persistence.Extras.Tests/DeDuplication/DeDuplicatingReceiverModelState.cs
+++ b/src/Akka.Persistence.Extras.Tests/DeDuplication/DeDuplicatingReceiverModelState.cs
@@ -49,11 +49,11 @@ namespace Akka.Persistence.Extras.Tests.DeDuplication
 
         public IReadOnlyDictionary<string, DateTime> TrackedSenders => SenderLru;
 
-        public (IReceiverState newState, IReadOnlyList<string> prunedSenders) Prune(TimeSpan notUsedSince)
+        public PrunedResult Prune(TimeSpan notUsedSince)
         {
             var targetTime = CurrentTime - notUsedSince;
             var prunedSenderIds = SenderLru.Where(x => x.Value <= targetTime).Select(x => x.Key).ToList();
-            return (
+            return new PrunedResult(
                 new DeDuplicatingReceiverModelState(SenderLru.RemoveRange(prunedSenderIds),
                     SenderIds.RemoveRange(prunedSenderIds), CurrentTime), prunedSenderIds);
         }

--- a/src/Akka.Persistence.Extras/Akka.Persistence.Extras.csproj
+++ b/src/Akka.Persistence.Extras/Akka.Persistence.Extras.csproj
@@ -3,7 +3,7 @@
 
 
   <PropertyGroup>
-    <TargetFramework>netstandard2.0</TargetFramework>
+    <TargetFrameworks>$(NetStandardLibVersion);$(NetFrameworkLibVersion)</TargetFrameworks>
     <Description>Additional features and tools for the Akka.Persistence library.</Description>
   </PropertyGroup>
 
@@ -12,5 +12,4 @@
     <PackageReference Include="Akka.Persistence" Version="$(AkkaVersion)" />
     <PackageReference Include="Petabridge.Collections" Version="1.0.0" />
   </ItemGroup>
-
 </Project>

--- a/src/common.props
+++ b/src/common.props
@@ -15,6 +15,8 @@ You can read more about [how to use the `DeDuplicatingReceiveActor` with Akka.NE
     <NoWarn>$(NoWarn);CS1591</NoWarn>
   </PropertyGroup>
   <PropertyGroup>
+    <NetFrameworkLibVersion>net45</NetFrameworkLibVersion>
+    <NetStandardLibVersion>netstandard1.6</NetStandardLibVersion>
     <AkkaVersion>1.3.2</AkkaVersion>
     <NBenchVersion>1.2.2</NBenchVersion>
     <XunitVersion>2.4.1</XunitVersion>

--- a/src/common.props
+++ b/src/common.props
@@ -2,9 +2,10 @@
   <PropertyGroup>
     <Copyright>Copyright © 2015-2019 Petabridge</Copyright>
     <Authors>Petabridge</Authors>
-    <VersionPrefix>0.1.0</VersionPrefix>
-    <PackageReleaseNotes>First release of Akka.Persistence.Extras. Introduces the [`DeDuplicatingReceiveActor` base class](https://devops.petabridge.com/api/Akka.Persistence.Extras.DeDuplicatingReceiveActor.html), which can be used to automatically strip out duplicates and guarantee that messages are processed exactly once by the actor.
-You can read more about [how to use the `DeDuplicatingReceiveActor` with Akka.NET and other `AtLeastOnceDeliveryActor` instances here](https://devops.petabridge.com/articles/msgdelivery/deduplication.html).</PackageReleaseNotes>
+    <VersionPrefix>0.2.0</VersionPrefix>
+    <PackageReleaseNotes>Minor, but breaking change release of Akka.Persistence.Extras.
+Changed targets to .NET 4.5 and .NET Standard 1.6, in order to temporarily bring the project inline with Akka.NET's targets. We will move back to targeting .NET Standard 2.0 eventually.
+Removed all dependencies on `System.ValueTuple` as this caused compilation issues on Linux with .NET Framework 4.5.</PackageReleaseNotes>
     <PackageIconUrl>https://petabridge.com/images/logo.png</PackageIconUrl>
     <PackageProjectUrl>
       https://devops.petabridge.com/articles/msgdelivery/


### PR DESCRIPTION
#### 0.2.0 February 15 2019 ####
Minor, but breaking change release of Akka.Persistence.Extras.

* Changed targets to .NET 4.5 and .NET Standard 1.6, in order to temporarily bring the project inline with Akka.NET's targets. We will move back to targeting .NET Standard 2.0 eventually.
* Removed all dependencies on `System.ValueTuple` as this caused compilation issues on Linux with .NET Framework 4.5.