### PR TITLE
added v0.4.1 release notes

### DIFF
--- a/RELEASE_NOTES.md
+++ b/RELEASE_NOTES.md
@@ -1,3 +1,4 @@
-#### 0.4.0 April 02 2019 ####
-* Upgraded to Akka.NET v1.3.12.
-* Added the `PersistenceSupervisor` to Akka.Persistence.Extras. This [actor is responsible for providing a more robust Akka.Persistence failure, recovery, and retry supervision model for Akka.NET](https://devops.petabridge.com/articles/state-management/akkadotnet-persistence-failure-handling.html).
+#### 0.4.1 May 09 2019 ####
+* Upgraded to Akka.NET v1.3.13.
+* Added the `ConfirmableMessage<T>` type to make it easier to work with `Receive<T>` and `Command<T>` handlers.
+* [added clearer warning message when attempting to confirm message that doesn't implement IConfirmableMessage interface](https://github.com/petabridge/Akka.Persistence.Extras/pull/39)

--- a/src/common.props
+++ b/src/common.props
@@ -2,9 +2,10 @@
   <PropertyGroup>
     <Copyright>Copyright © 2015-2019 Petabridge</Copyright>
     <Authors>Petabridge</Authors>
-    <VersionPrefix>0.4.0</VersionPrefix>
-    <PackageReleaseNotes>Upgraded to Akka.NET v1.3.12.
-Added the `PersistenceSupervisor` to Akka.Persistence.Extras. This [actor is responsible for providing a more robust Akka.Persistence failure, recovery, and retry supervision model for Akka.NET](https://devops.petabridge.com/articles/state-management/akkadotnet-persistence-failure-handling.html).</PackageReleaseNotes>
+    <VersionPrefix>0.4.1</VersionPrefix>
+    <PackageReleaseNotes>Upgraded to Akka.NET v1.3.13.
+Added the `ConfirmableMessage&lt;T&gt;` type to make it easier to work with `Receive&lt;T&gt;` and `Command&lt;T&gt;` handlers.
+[added clearer warning message when attempting to confirm message that doesn't implement IConfirmableMessage interface](https://github.com/petabridge/Akka.Persistence.Extras/pull/39)</PackageReleaseNotes>
     <PackageIconUrl>https://petabridge.com/images/logo.png</PackageIconUrl>
     <PackageProjectUrl>
       https://devops.petabridge.com/articles/msgdelivery/


### PR DESCRIPTION
#### 0.4.1 May 09 2019 ####
* Upgraded to Akka.NET v1.3.13.
* Added the `ConfirmableMessage<T>` type to make it easier to work with `Receive<T>` and `Command<T>` handlers.
* [added clearer warning message when attempting to confirm message that doesn't implement IConfirmableMessage interface](https://github.com/petabridge/Akka.Persistence.Extras/pull/39)