### PR TITLE
Use local sender variable rather than static property

### DIFF
--- a/src/Akka.Persistence.Extras/Supervision/PersistenceSupervisor.cs
+++ b/src/Akka.Persistence.Extras/Supervision/PersistenceSupervisor.cs
@@ -113,7 +113,7 @@ namespace Akka.Persistence.Extras
             if (CheckIsEvent(message))
             {
                 var confirmable = DoMakeEventConfirmable(message, ++_currentDeliveryId);
-                _eventBuffer[confirmable.ConfirmationId] = new PersistentEvent(confirmable, Sender);
+                _eventBuffer[confirmable.ConfirmationId] = new PersistentEvent(confirmable, sender);
                 Child.Tell(confirmable, sender);
             }
             else if (message is Confirmation confirmation)


### PR DESCRIPTION
I am not sure if using Sender rather than sender here was intentional, but it looks wrong. We believe it is currently a possible reason for a bug we have where a second message, received when the PersitentActor is rebooted, don't get the expected reply back to its sender.